### PR TITLE
chore(vuln): replace GITHUB_ENV with GITHUB_OUTPUT in rudder-cli action (SEC-162)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -56,22 +56,23 @@ runs:
         fi
 
     - name: Set github action version and platform
+      id: set-env
       shell: bash
       env:
         ACTION_REF: ${{ github.action_ref }}
       run: |
-        # zizmor: ignore[github-env]  # literal value, not user-controlled
-        echo "RUDDERSTACK_CLI_CI_PLATFORM=github-actions" >> $GITHUB_ENV
-        # zizmor: ignore[github-env]  # github.action_ref is the action's own ref, not user-controlled
-        echo "RUDDERSTACK_CLI_WORKFLOW_VERSION=$ACTION_REF" >> $GITHUB_ENV
+        echo "RUDDERSTACK_CLI_CI_PLATFORM=github-actions" >> "$GITHUB_OUTPUT"
+        echo "RUDDERSTACK_CLI_WORKFLOW_VERSION=${ACTION_REF}" >> "$GITHUB_OUTPUT"
         echo "CI platform: github-actions"
-        echo "Workflow version: $ACTION_REF"
+        echo "Workflow version: ${ACTION_REF}"
 
     - name: Validate project files
       if: inputs.mode == 'validate'
       shell: bash
       env:
         INPUT_LOCATION: ${{ inputs.location }}
+        RUDDERSTACK_CLI_CI_PLATFORM: ${{ steps.set-env.outputs.RUDDERSTACK_CLI_CI_PLATFORM }}
+        RUDDERSTACK_CLI_WORKFLOW_VERSION: ${{ steps.set-env.outputs.RUDDERSTACK_CLI_WORKFLOW_VERSION }}
       run: |
         rudder-cli validate -l "$INPUT_LOCATION"
 
@@ -80,6 +81,8 @@ runs:
       shell: bash
       env:
         INPUT_LOCATION: ${{ inputs.location }}
+        RUDDERSTACK_CLI_CI_PLATFORM: ${{ steps.set-env.outputs.RUDDERSTACK_CLI_CI_PLATFORM }}
+        RUDDERSTACK_CLI_WORKFLOW_VERSION: ${{ steps.set-env.outputs.RUDDERSTACK_CLI_WORKFLOW_VERSION }}
       run: |
         rudder-cli apply -l "$INPUT_LOCATION" --dry-run
 
@@ -88,5 +91,7 @@ runs:
       shell: bash
       env:
         INPUT_LOCATION: ${{ inputs.location }}
+        RUDDERSTACK_CLI_CI_PLATFORM: ${{ steps.set-env.outputs.RUDDERSTACK_CLI_CI_PLATFORM }}
+        RUDDERSTACK_CLI_WORKFLOW_VERSION: ${{ steps.set-env.outputs.RUDDERSTACK_CLI_WORKFLOW_VERSION }}
       run: |
         rudder-cli apply -l "$INPUT_LOCATION" --confirm=false


### PR DESCRIPTION
## Summary
- Replace `$GITHUB_ENV` with `$GITHUB_OUTPUT` for `RUDDERSTACK_CLI_CI_PLATFORM` and `RUDDERSTACK_CLI_WORKFLOW_VERSION`
- Pass `github.action_ref` via step-level `env:` to avoid script injection
- Add explicit `env:` blocks on consumer steps (validate, dry-run, apply) to forward outputs as process environment variables
- Eliminates zizmor `github-env` finding

## Test plan
- [ ] Verify rudder-cli action works correctly in a test repo
- [ ] Confirm zizmor check passes